### PR TITLE
Fix two broken internal links

### DIFF
--- a/_posts/2025-10-21-praten.md
+++ b/_posts/2025-10-21-praten.md
@@ -11,7 +11,7 @@ tags:
 ---
 
 Week 116 bij de overheid. Het is een tijdje stil geweest. In juli schreef ik
-nog [Wat ben je aan het doen?](/2025/07/11/wat-ben-je-aan-het-doen.html). Daarna niets meer.
+nog [Wat ben je aan het doen?](/2025/07/10/wat-ben-je-aan-het-doen.html). Daarna niets meer.
 
 Er is veel gebeurd. In mei is mijn derde dochter geboren - daar ben ik natuurlijk nog steeds druk mee. Mijn vrijdagen
 besteed ik nu bij [DittoCare](https://ditto.care), waar ik help met het evalueren of LLM's doen wat ze moeten

--- a/_posts/2025-10-23-linked-data-considered-harmful.md
+++ b/_posts/2025-10-23-linked-data-considered-harmful.md
@@ -183,7 +183,7 @@ Na bijna twee decennia heeft linked data bewezen dat het geen revolutie gaat bre
 Het is tijd om dat te erkennen en verder te gaan.
 
 Als je dit leest en denkt "maar linked data heeft ons enorm geholpen!", dan ben ik oprecht benieuwd naar je
-ervaring. [Stuur me een bericht](/about). Misschien leer ik iets nieuws. Maar na 20 jaar wachten op de Semantische Web
+ervaring. [Stuur me een bericht](/about/). Misschien leer ik iets nieuws. Maar na 20 jaar wachten op de Semantische Web
 revolutie ben ik niet optimistisch.
 
 Voorlopig blijf ik [maken boven schrijven](/2025/04/11/maken-over-schrijven.html): JSON schrijven, API's bouwen,


### PR DESCRIPTION
## Summary
- `praten.md`: link to "Wat ben je aan het doen?" pointed at `/2025/07/11/...` but the post is dated `07-10`. Another link later in the same post already uses the correct date.
- `linked-data-considered-harmful.md`: `/about` missing trailing slash (permalink is `/about/`).

Found via `check_links.py`. The other items it flags are false positives: it doesn't resolve permalinks on root-level `.markdown` files, and it can't verify anchors.

## Test plan
- [ ] Jekyll build is green
- [ ] `/2025/07/10/wat-ben-je-aan-het-doen.html` resolves from the praten post
- [ ] `/about/` resolves from the linked-data post