### PR TITLE
Voeg genegeerde _drafts/-map toe voor concepten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ __pycache__/
 .venv/
 .ruff_cache/
 .playwright-mcp/
+
+# Unpublished drafts, never checked in. Jekyll skips _drafts unless
+# --drafts is passed, and check_links.py only scans _posts.
+_drafts/


### PR DESCRIPTION
Concepten horen niet in GitHub. Deze PR voegt een `_drafts/`-map toe die in `.gitignore` staat.

- Jekyll bouwt `_drafts/` alleen met `--drafts`, dus de site verandert niet.
- `check_links.py` scant alleen `_posts`, dus losse concepten blokkeren de pre-commit link-check niet meer.
- De drie bestaande ongepubliceerde concepten (`2025-07-11-100-weken-later.md`, `2025-07-18-stam.md`, `2025-12-13-wat-mist.md`) zijn lokaal naar `_drafts/` verplaatst en blijven ongetrackt.