### PR TITLE
Koppel publicaties en software bidirectioneel

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -59,6 +59,17 @@ layout: default
         {% endfor %}
         </p>
     {% endif %}
+    {% assign related_software = site.software | where_exp: "s", "s.publications contains page.key" | sort: "order" %}
+    {% if related_software.size > 0 %}
+        <h2>Related Software</h2>
+        <p>
+        {% for sw in related_software %}
+            <a href="/software/#{{ sw.slug }}"><i class="fa fa-code"></i> {{ sw.title }}</a>
+            {%- if sw.summary %} &mdash; {{ sw.summary }}{% endif %}
+            <br>
+        {% endfor %}
+        </p>
+    {% endif %}
     <h2>Bib</h2>
 <pre>
 @{{page.type}}{ {{- page.key}},

--- a/_software/lerot.md
+++ b/_software/lerot.md
@@ -4,12 +4,20 @@ slug: lerot-an-online-learning-to-rank-framework
 order: 6
 repo: https://bitbucket.org/ilps/lerot
 summary: Framework for running online learning-to-rank experiments for information retrieval; described in a CIKM'13 workshop paper.
+publications:
+  - schuth2013lerot
+  - chuklin2013evaluating
+  - chuklin2014
+  - chuklin2015
+  - hofmann2013reusing
+  - hofmann2014
+  - oosterhuis2016
+  - schuth2014
+  - schuth2014multileaved
+  - schuth2015probabilistic
+  - schuth2016multileave
+  - schuth-phd-thesis-2016
 ---
 Lerot is a framework, designed to run experiments on online learning to rank methods for information retrieval. It has
 mainly been developed by [Katja Hofmann](http://khofm.wordpress.com/) and Anne Schuth.
 The source code of Lerot is [available from bitbucket](https://bitbucket.org/ilps/lerot).
-A paper describing Lerot is published in the Living Labs Workshop at CIKM'13:
-
-- A. Schuth, K. Hofmann, S. Whiteson, M. de
-  Rijke. [Lerot: an Online Learning to Rank Framework](/publications/schuth2013lerot.html)
-  In Living Labs for Information Retrieval Evaluation workshop at CIKM'13, 2013

--- a/_software/living-labs.md
+++ b/_software/living-labs.md
@@ -4,6 +4,10 @@ slug: living-labs
 order: 5
 repo: https://github.com/living-labs/ll-api
 summary: RESTful API for the Living Labs for IR Evaluation (LL4IR / CLEF lab) letting researchers evaluate rankers on real users of real search engines.
+publications:
+  - schuth2015extended
+  - schuth2015opensearch
+  - schuth2015overview
 ---
 The Living Labs for IR Evaluation (LL4IR) is a new evaluation paradigm. I implemented an API for participants (
 researchers) and sites (search engines) that take part in this Living Lab (which is also run
@@ -18,11 +22,3 @@ GET, PUT and DELETE.
 The source code is [available on GitHub](https://github.com/living-labs/ll-api).
 
 It has mainly been developed by Anne Schuth and [Krisztian Balog](http://krisztianbalog.com/).
-
-**Related publications:**
-
-- [Extended Overview of the Living Labs for Information Retrieval Evaluation (LL4IR) CLEF Lab 2015](/publications/schuth2015extended.html)
-- [OpenSearch: Integrating and Contextualizing Search](/publications/schuth2015opensearch.html)
-- [Overview of the CLEF LL4IR 2015 Lab](/publications/schuth2015overview.html)
-- [Living Labs for Online Evaluation: From Theory to Practice](/talks/living-labs-for-online-evaluation-from-theory-to-p-2016.html)
-- [TREC OpenSearch Track](/talks/trec-opensearch-2015.html)

--- a/software.markdown
+++ b/software.markdown
@@ -11,4 +11,42 @@ permalink: /software/
 ## {{ project.title }} {#{{ project.slug }}}
 
 {{ project.content }}
+{% if project.publications and project.publications.size > 0 %}
+{%- assign resolved_pubs = '' | split: '' -%}
+{%- for key in project.publications -%}
+  {%- assign pub = site.publications | where: "key", key | first -%}
+  {%- unless pub -%}
+    {%- assign pub_filename = key | append: ".md" -%}
+    {%- for p in site.publications -%}
+      {%- assign p_filename = p.path | split: "/" | last -%}
+      {%- if p_filename == pub_filename -%}{%- assign pub = p -%}{%- break -%}{%- endif -%}
+    {%- endfor -%}
+  {%- endunless -%}
+  {%- if pub -%}{%- assign resolved_pubs = resolved_pubs | push: pub -%}{%- endif -%}
+{%- endfor -%}
+{% if resolved_pubs.size > 0 %}
+**Related publications:**
+
+{% assign sorted_pubs = resolved_pubs | sort: "date" | reverse %}
+{% for pub in sorted_pubs %}- [{{ pub.title }}]({{ pub.url }}). _{{ pub.author | replace: "Anne Schuth", "**Anne Schuth**" }}._{% if pub.booktitle %} In {{ pub.booktitle }},{% endif %}{% if pub.journal %} In {{ pub.journal }},{% endif %} {{ pub.year }}.
+{% endfor %}
+{%- assign related_talks = '' | split: '' -%}
+{%- for talk in site.talks -%}
+  {%- if talk.publication_url -%}
+    {%- assign talk_pub_key = talk.publication_url | replace: '/publications/', '' | replace: '.html', '' | replace: '/', '' -%}
+    {%- for pub in resolved_pubs -%}
+      {%- assign pub_key = pub.url | replace: '/publications/', '' | replace: '.html', '' | replace: '/', '' -%}
+      {%- if talk_pub_key == pub_key -%}{%- assign related_talks = related_talks | push: talk -%}{%- break -%}{%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endfor -%}
+{% if related_talks.size > 0 %}
+**Related talks:**
+
+{% assign sorted_talks = related_talks | sort: "date" | reverse %}
+{% for talk in sorted_talks %}- [{{ talk.title }}]({{ talk.url }}).{% if talk.venue %} _{{ talk.venue }}_.{% endif %}{% if talk.location %} {{ talk.location }}.{% endif %} _{{ talk.date | date: "%b %-d, %Y" }}_.
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
## Wat

Publicaties en software zijn nu wederzijds gekoppeld via één bron van waarheid: een `publications:`-lijst in de front matter van elk software-item. Dit volgt hetzelfde patroon als de bestaande publicatie↔talk-koppeling.

- **Publicatiepagina** toont een "Related Software"-blok via reverse lookup op `page.key`.
- **Softwarepagina** genereert per project de gerelateerde publicaties én (transitief, via de talk↔publicatie-koppeling) de gerelateerde talks.
- De handmatig onderhouden prozalijstjes in `lerot.md` en `living-labs.md` zijn verwijderd; de koppeling wordt nu op één plek beheerd in plaats van te verouderen.

## Scope van de koppelingen

- **Lerot**: het introducerende paper, het proefschrift, en de 10 papers die `Lerot` als expliciete keyword-tag dragen (papers die met Lerot hebben geëxperimenteerd).
- **Living Labs**: exact de drie LL4IR-papers uit de oorspronkelijke proza (`schuth2015extended`, `schuth2015opensearch`, `schuth2015overview`). De bredere "living labs"-keyword tagt het onderzoeksparadigma, niet de `ll-api`-software, dus die papers zijn bewust niet gekoppeld.
- AMT, claude-threads, peerpressure en regelrecht hebben geen papers en renderen ongewijzigd, zonder lege koppen.

## Getest

- `bundle exec jekyll build` slaagt zonder Liquid-waarschuwingen.
- Gerenderde HTML gecontroleerd: keyword-getagde papers en het proefschrift linken naar Lerot; de drie LL4IR-papers naar Living Labs; `baan2019` (geen software) heeft geen Related Software-kop.
- Softwarepagina: Lerot toont 12 publicaties, Living Labs de 3 plus de twee eerder handmatig getypte talks, nu afgeleid.