### PR TITLE
Werk doorlooptijd bij van 93 naar 160 dagen

### DIFF
--- a/_posts/2026-03-20-techbedrijf.md
+++ b/_posts/2026-03-20-techbedrijf.md
@@ -47,7 +47,7 @@ Bij [Spotify](/joining-spotify/) hoefden productteams zich niet bezig te houden 
 
 [^backstage]: [Supercharged Developer Portals](https://engineering.atspotify.com/2024/04/supercharged-developer-portals/), Spotify Engineering, april 2024. De studie vergeleek frequente met infrequente Backstage-gebruikers. Er was geen controlegroep.
 
-Voor de overheid betekent dit: in plaats van dat elke uitvoeringsorganisatie zelf een Kubernetes-cluster opzet en zelf security scanning inricht, bied je dat aan als self-service. Een team dat een nieuwe service moet bouwen klikt op "new project" en krijgt een repo met CI/CD, monitoring, security scanning, en deployment naar een compliant omgeving. In minuten. In plaats van [93 dagen](/2025/03/07/hosting-in-slow-motion.html).
+Voor de overheid betekent dit: in plaats van dat elke uitvoeringsorganisatie zelf een Kubernetes-cluster opzet en zelf security scanning inricht, bied je dat aan als self-service. Een team dat een nieuwe service moet bouwen klikt op "new project" en krijgt een repo met CI/CD, monitoring, security scanning, en deployment naar een compliant omgeving. In minuten. In plaats van [160 dagen](/2025/03/07/hosting-in-slow-motion.html).
 
 ## Argument 5: Bijzonder genoeg
 

--- a/_posts/2026-06-22-het-platform.md
+++ b/_posts/2026-06-22-het-platform.md
@@ -28,7 +28,7 @@ Platform engineering pakt die onderbouw, maakt hem één keer goed, door een tea
 
 In dat woordje zélf zit het verschil met het oude beheer. De ontwikkelaar blijft aan het stuur, maar bouwt niet meer alles zelf. De voorziening is er al, hij pakt die en gaat door met zijn eigenlijke werk. Vroeger was het: dien een verzoek in en wij doen het, op onze tijd. Nu is het: hier staat het, gebruik het wanneer je wilt, wij houden het goed. Hij drukt op de knop, het platformteam zorgt dat er iets deugdelijks achter zit.
 
-Dat is in [Techbedrijf](/2026/03/20/techbedrijf.html) de multiplier: een team klikt op "nieuw project" en krijgt een repository met CI/CD, monitoring, beveiligingsscans en een uitrol naar een omgeving die aan de eisen voldoet. In minuten, waar het nu [93 dagen](/2025/03/07/hosting-in-slow-motion.html) kost. Maar het werkt alleen als teams de voorziening ook echt gaan gebruiken. Daar zit de kern van platform engineering, en die kern is een handvol ideeën die ik stuk voor stuk wil langslopen.
+Dat is in [Techbedrijf](/2026/03/20/techbedrijf.html) de multiplier: een team klikt op "nieuw project" en krijgt een repository met CI/CD, monitoring, beveiligingsscans en een uitrol naar een omgeving die aan de eisen voldoet. In minuten, waar het nu [160 dagen](/2025/03/07/hosting-in-slow-motion.html) kost. Maar het werkt alleen als teams de voorziening ook echt gaan gebruiken. Daar zit de kern van platform engineering, en die kern is een handvol ideeën die ik stuk voor stuk wil langslopen.
 
 ## Het gebaande pad
 


### PR DESCRIPTION
De doorlooptijd die in twee vooruitkijkende posts wordt geciteerd is bijgewerkt van 93 naar 160 dagen:

- `_posts/2026-06-22-het-platform.md` — "waar het nu 160 dagen kost"
- `_posts/2026-03-20-techbedrijf.md` — "In plaats van 160 dagen"

Het historische verslag in `_posts/2025-03-07-hosting-in-slow-motion.md` is ongemoeid gelaten, omdat 93 dagen daar feitelijk correct is voor die datum (7 maart 2025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014emKQgnmvzHyFhXLPniYbZ)_