### PR TITLE
Voeg Floortje Bos toe aan teaching-pagina

### DIFF
--- a/_students/bos-floortje.md
+++ b/_students/bos-floortje.md
@@ -1,0 +1,12 @@
+---
+name: Floortje Bos
+degree: MSc AI at the Vrije Universiteit Amsterdam
+years: "2026"
+host_company: Ministry of the Interior and Kingdom Relations
+topic: From Rule Execution to Citizen Explanation - Evaluating LLM-Generated Explanations in Rule-Based Government Systems
+co_supervisors: [Jieying Chen]
+layout: student
+github_url: https://github.com/Bosfloortje/machine-law-thesis-flora
+---
+
+Floortje's thesis investigated how graph-structured representations of rule-based government decision processes can be integrated with LLMs to generate citizen-focused explanations that are legally grounded and faithful to the underlying rule-execution trace. She built a graph-based explanation pipeline for three Dutch legal domains (Zorgtoeslagwet, Participatiewet, and Alcoholwet), evaluating the generated explanations for legal grounding, faithfulness, and citizen comprehensibility.


### PR DESCRIPTION
## Summary
- Voegt Floortje Bos toe aan de teaching-pagina als student (masterscriptie AI, VU Amsterdam)
- Daily supervisor: Anne, host organisatie BZK, co-supervisor Jieying Chen
- Onderwerp: "From Rule Execution to Citizen Explanation: Evaluating LLM-Generated Explanations in Rule-Based Government Systems"

## Test plan
- [x] `bundle exec jekyll build` succeeds
- [x] Entry rendert correct op de teaching-pagina (sorteert bovenaan op jaar 2026)
- [x] Individuele studentpagina rendert correct