### PR TITLE
Link het reisblog-archief in het More-menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,6 +31,7 @@
           <div class="dropdown-menu">
             <a href="{{ "/activities/" | relative_url }}">Activities</a>
             <a href="{{ "/press/" | relative_url }}">Press</a>
+            <a href="{{ "/reisblog/" | relative_url }}">Reisblog &#8217;07&#8211;&#8217;08</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Follow-up op #61: het archief was alleen vanaf de about-pagina vindbaar. Voegt "Reisblog '07–'08" toe aan de bestaande More-dropdown in de navigatie (naast Activities en Press) — vindbaar, maar nog steeds onopvallend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yWfXeG3Hkof9DKwY1zSTR

---
_Generated by [Claude Code](https://claude.ai/code/session_015yWfXeG3Hkof9DKwY1zSTR)_