### PR TITLE
Reisarchief: ingezoomd trajectkaartje boven elk verslag

### DIFF
--- a/_includes/reisblog-postkaart.html
+++ b/_includes/reisblog-postkaart.html
@@ -1,0 +1,78 @@
+<link rel="stylesheet" href="/assets/vendor/leaflet/leaflet.css" />
+{%- if page.collection == "reisblog_india" -%}
+  {%- assign kaarturl = "/reisblog/india/kaart/" -%}
+{%- else -%}
+  {%- assign kaarturl = "/reisblog/fietsen/kaart/" -%}
+{%- endif -%}
+{%- assign slug = page.url | split: "/" | last -%}
+<div id="reisblog-postmap" title="Het traject van dit verslag &mdash; klik voor de hele reiskaart"></div>
+<p class="reisblog-postmap-caption">Het traject van dit bericht &middot; <a href="{{ kaarturl | relative_url }}#{{ slug }}">bekijk de hele reiskaart</a></p>
+<script src="/assets/vendor/leaflet/leaflet.js"></script>
+<script>
+  (function () {
+    {%- assign posts = site[page.collection] | where_exp: "p", "p.lat" | sort: "date" %}
+    // De hele route (alleen coördinaten) als vage contextlijn.
+    var route = [
+      {%- for p in posts -%}
+      {%- for w in p.route -%}[{{ w.lat }},{{ w.lng }}],{% endfor -%}
+      [{{ p.lat }},{{ p.lng }}]{%- unless forloop.last %},{% endunless -%}
+      {%- endfor -%}
+    ];
+    {%- assign curi = -1 -%}
+    {%- for p in posts -%}
+      {%- if p.url == page.url -%}{%- assign curi = forloop.index0 -%}{%- endif -%}
+    {%- endfor -%}
+    {%- assign previ = curi | minus: 1 -%}
+    {%- assign prev = posts[previ] %}
+    // Het traject van dit bericht: vorige schrijflocatie, tussenstops, schrijflocatie.
+    var leg = [
+      {%- if curi > 0 %}
+      { lat: {{ prev.lat }}, lng: {{ prev.lng }}, name: {{ prev.title | jsonify }}, kind: "prev" },
+      {%- endif %}
+      {%- for w in page.route %}
+      { lat: {{ w.lat }}, lng: {{ w.lng }}, name: {{ w.name | jsonify }}, kind: "wp" },
+      {%- endfor %}
+      { lat: {{ page.lat }}, lng: {{ page.lng }}, name: {{ page.title | jsonify }}, kind: "main" }
+    ];
+
+    var el = document.getElementById('reisblog-postmap');
+    var map = L.map(el, {
+      dragging: false, scrollWheelZoom: false, doubleClickZoom: false,
+      boxZoom: false, keyboard: false, touchZoom: false, zoomControl: false
+    });
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+    }).addTo(map);
+
+    var styles = getComputedStyle(document.documentElement);
+    var accent = styles.getPropertyValue('--accent-color').trim() || '#c2410c';
+    var alt = styles.getPropertyValue('--route-alt-color').trim() || '#3d6f9e';
+
+    L.polyline(route, { color: '#888888', weight: 1.5, opacity: 0.35, dashArray: '4 6', interactive: false }).addTo(map);
+    L.polyline(leg.map(function (p) { return [p.lat, p.lng]; }),
+      { color: accent, weight: 3, opacity: 0.75, interactive: false }).addTo(map);
+
+    leg.forEach(function (p) {
+      if (p.kind === 'wp') {
+        L.circleMarker([p.lat, p.lng], {
+          radius: 3.5, color: alt, weight: 1.5, fillColor: alt, fillOpacity: 0.6, interactive: false
+        }).addTo(map);
+      } else if (p.kind === 'prev') {
+        L.circleMarker([p.lat, p.lng], {
+          radius: 4, color: '#888888', weight: 1.5, fillColor: '#888888', fillOpacity: 0.4, interactive: false
+        }).addTo(map);
+      } else {
+        L.circleMarker([p.lat, p.lng], {
+          radius: 6, color: accent, weight: 2, fillColor: accent, fillOpacity: 0.6, interactive: false
+        }).addTo(map);
+      }
+    });
+
+    map.fitBounds(leg.map(function (p) { return [p.lat, p.lng]; }), { padding: [28, 28], maxZoom: 9 });
+
+    el.addEventListener('click', function () {
+      window.location.href = {{ kaarturl | relative_url | jsonify }} + '#' + {{ slug | jsonify }};
+    });
+  })();
+</script>

--- a/_layouts/reisblog.html
+++ b/_layouts/reisblog.html
@@ -12,15 +12,12 @@ layout: default
     <h1 class="post-title" itemprop="name headline">{{ page.title | escape }}</h1>
     <p class="post-meta">
       <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date_display }}</time>
-      {%- assign slug = page.url | split: "/" | last -%}
-      {%- if page.collection == "reisblog_india" -%}
-        {%- assign kaarturl = "/reisblog/india/kaart/" -%}
-      {%- else -%}
-        {%- assign kaarturl = "/reisblog/fietsen/kaart/" -%}
-      {%- endif -%}
-      {%- if page.lat %} &middot; <a href="{{ kaarturl | relative_url }}#{{ slug }}" title="Waar dit bericht geschreven werd, op de reiskaart">schrijflocatie</a>{% endif -%}
     </p>
   </header>
+
+  {%- if page.lat %}
+  {% include reisblog-postkaart.html %}
+  {%- endif %}
 
   <div class="post-content" itemprop="articleBody">
     {{ content }}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -22,6 +22,7 @@
   --button-bg: transparent;
   --button-hover: #ece7db;
   --accent-color: #c2410c;
+  --route-alt-color: #3d6f9e;
   --selection-bg: rgba(194, 65, 12, 0.18);
 }
 
@@ -45,6 +46,7 @@
   --button-bg: transparent;
   --button-hover: #1a1a1c;
   --accent-color: #ff7a45;
+  --route-alt-color: #7fb2e5;
   --selection-bg: rgba(255, 122, 69, 0.22);
 }
 
@@ -1622,6 +1624,26 @@ mark {
 [data-theme="dark"] #reisblog-map .leaflet-layer,
 [data-theme="dark"] #reisblog-map .leaflet-control-zoom,
 [data-theme="dark"] #reisblog-map .leaflet-control-attribution {
+  filter: invert(1) hue-rotate(180deg) brightness(0.9) contrast(0.9);
+}
+
+#reisblog-postmap {
+  height: 230px;
+  margin: 0.75em 0 0.35em;
+  border: 1px solid var(--border-strong);
+  background: var(--code-bg);
+  z-index: 0;
+  cursor: pointer;
+}
+
+.reisblog-postmap-caption {
+  margin: 0 0 1.5em;
+  font-size: 0.8em;
+  color: var(--text-muted);
+}
+
+[data-theme="dark"] #reisblog-postmap .leaflet-layer,
+[data-theme="dark"] #reisblog-postmap .leaflet-control-attribution {
   filter: invert(1) hue-rotate(180deg) brightness(0.9) contrast(0.9);
 }
 


### PR DESCRIPTION
Elk verslag met een schrijflocatie krijgt bovenaan een klein kaartje dat inzoomt op het traject dat dat bericht beschrijft, ter vervanging van de kale "schrijflocatie"-link in de metaregel.

## Hoe het eruitziet

- **Oranje lijn**: het traject van dit bericht — van de vorige schrijflocatie (grijs puntje), via de tussenstops uit de tekst (blauwe stipjes, `--route-alt-color`), naar de schrijflocatie zelf (accentkleurig hoofdpunt).
- **Grijze stippellijn**: de rest van de hele route, vaag op de achtergrond voor context.
- Het kaartje is niet-interactief (geen zoom/sleep); klikken — of de link eronder — opent de grote reiskaart, ingezoomd op dit verslag (bestaande `#slug`-deep-link).
- Nieuwe include `reisblog-postkaart.html`; kleurvariabele en stijlen (incl. dark-mode tegelfilter) in `main.scss`. Eerste posts (geen vorige locatie) en posts zonder lat/lng (geen kaartje) zijn afgedekt.

## Checks

Jekyll-build, `check_links.py` (0 broken) en `check_yaml.py` (nu incl. reisblogcollecties) groen; gegenereerde kaart-JS van meerdere posts door `node --check` gehaald; pagina's headless gerenderd en visueel gecontroleerd (o.a. de Annapurna-lus bij "Een biertje op 5416 meter").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yWfXeG3Hkof9DKwY1zSTR

---
_Generated by [Claude Code](https://claude.ai/code/session_015yWfXeG3Hkof9DKwY1zSTR)_