### PR TITLE
Reiskaarten: Latijnse plaatsnamen (CARTO Voyager-tegels)

### DIFF
--- a/_includes/reisblog-kaart.html
+++ b/_includes/reisblog-kaart.html
@@ -18,9 +18,10 @@
     var mains = points.filter(function (p) { return p.main; });
     if (!mains.length) { return; }
     var map = L.map('reisblog-map', { scrollWheelZoom: false });
-    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
       maxZoom: 19,
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>-bijdragers'
+      subdomains: 'abcd',
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>-bijdragers &copy; <a href="https://carto.com/attributions">CARTO</a>'
     }).addTo(map);
 
     var accent = getComputedStyle(document.documentElement)

--- a/_includes/reisblog-postkaart.html
+++ b/_includes/reisblog-postkaart.html
@@ -40,9 +40,10 @@
       dragging: false, scrollWheelZoom: false, doubleClickZoom: false,
       boxZoom: false, keyboard: false, touchZoom: false, zoomControl: false
     });
-    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
       maxZoom: 19,
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+      subdomains: 'abcd',
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
     }).addTo(map);
 
     var styles = getComputedStyle(document.documentElement);


### PR DESCRIPTION
De standaard-OSM-tegels tonen plaatsnamen in het lokale schrift (Devanagari in India, Tibetaans, Arabisch…). Beide reiskaarten en de trajectkaartjes boven de posts gebruiken nu de CARTO Voyager-basemap (OSM-data, gratis met attributie), die plaatsnamen in Latijns/Engels schrift toont — geverifieerd op tegels van India/Nepal ("NEPAL, Kathmandu, Varanasi, KOLKATA"). Retina-ondersteuning via het `{r}`-suffix; attributie uitgebreid met CARTO.

## Checks
Jekyll-build en `check_links.py` groen; tegel-URL's handmatig geverifieerd (200, image/png, Latijnse labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yWfXeG3Hkof9DKwY1zSTR

---
_Generated by [Claude Code](https://claude.ai/code/session_015yWfXeG3Hkof9DKwY1zSTR)_