### PR TITLE
Reisarchief: archiefnoot bij het foto-mailtje van Wout

### DIFF
--- a/_reisblog_india/de-laatste-fotos-voorlopig.md
+++ b/_reisblog_india/de-laatste-fotos-voorlopig.md
@@ -8,4 +8,6 @@ author: Wout
 location: "Nederland (thuis, vermoedelijk Zaanstreek)"
 ---
 
-<p>Dag Mensen,</p><p>Hier zijn dan de laatste foto's van Anne die jullie voorlopig te zien krijgen, bij de volgende serie zal Anne namelijk al in Nederland zijn (dat is dus pas na 13 Augustus). De reden hiervoor is dat ik (Wout) ook naar India ga om Anne op te zoeken en de website zal dus na 3 juli ook niet meer bij worden gewerkt.</p><p>De reisverslagen zullen wel gewoon tot het einde toe worden gemaild, maar dus niet op de website staan.</p><p>Hier zijn dus de foto's:</p><p>Veel kijk plezier<br />Groeten Wout</p>
+<p class="reisblog-note">Archiefnoot: dit mailtje is niet van mij maar van m&#8217;n broertje Wout, die vanuit Nederland de website met foto&#8217;s bijhield &mdash; tot hij op 3 juli zelf naar India vertrok en <a href="/reisblog/india/de-schaar-in-die-krullen/">de rest van de reis meeschreef</a>. De foto&#8217;s waar hij naar verwijst stonden op die (allang verdwenen) site.</p>
+
+<p>Dag Mensen,</p><p>Hier zijn dan de laatste foto's van Anne die jullie voorlopig te zien krijgen, bij de volgende serie zal Anne namelijk al in Nederland zijn (dat is dus pas na 13 Augustus). De reden hiervoor is dat ik (Wout) ook naar India ga om Anne op te zoeken en de website zal dus na 3 juli ook niet meer bij worden gewerkt.</p><p>De reisverslagen zullen wel gewoon tot het einde toe worden gemaild, maar dus niet op de website staan.</p><p>Veel kijk plezier<br />Groeten Wout</p>


### PR DESCRIPTION
Het mailtje *De laatste foto's (voorlopig)* (24 juni 2004) las wat vreemd: het is niet van Anne maar van Wout, die vanuit Nederland de fotosite bijhield, en na de eerdere linkopschoning eindigde het op een kale "Hier zijn dus de foto's:" die nergens meer heen wees.

- Nieuwe archiefnoot bovenaan (zelfde stijl als bij *Miranda, onze kip, ontsnapt*): legt uit dat Wout dit stuurde, dat hij op 3 juli zelf naar India vertrok en de rest van de reis meeschreef (met crosslink), en dat de foto's op de allang verdwenen site stonden.
- De hangende regel "Hier zijn dus de foto's:" is verwijderd.

## Checks
Jekyll-build en `check_links.py` (0 broken) groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yWfXeG3Hkof9DKwY1zSTR

---
_Generated by [Claude Code](https://claude.ai/code/session_015yWfXeG3Hkof9DKwY1zSTR)_