### PR TITLE
Redesign site navigation for mobile and desktop

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,37 @@
+# Site navigation. Rendered by _includes/header.html for both the desktop
+# nav (dropdowns) and the mobile panel (grouped list).
+- title: About
+  url: /about/
+- title: CV
+  url: /cv/
+- title: Writing
+  url: /
+- title: Software
+  url: /software/
+- title: Research
+  url: /publications/
+  children:
+    - title: Publications
+      url: /publications/
+    - title: Talks
+      url: /talks/
+    - title: Thesis
+      url: /thesis/
+    - title: Teaching
+      url: /teaching/
+- title: Reizen
+  url: /reisblog/
+  children:
+    - title: Reisarchief
+      url: /reisblog/
+    - title: "Fietsen ’07–’08"
+      url: /reisblog/fietsen/
+    - title: "India ’03–’04"
+      url: /reisblog/india/
+- title: More
+  url: /activities/
+  children:
+    - title: Activities
+      url: /activities/
+    - title: Press
+      url: /press/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,44 +2,54 @@
   <div class="wrapper">
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}" aria-label="{{ site.title | escape }}">anneschuth</a>
 
-    <nav class="site-nav">
+    <nav class="site-nav" aria-label="Site navigation">
       <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-      <label for="nav-trigger">
-        <span class="menu-icon">
-          <svg viewBox="0 0 18 15" width="18px" height="15px">
-            <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
-          </svg>
-        </span>
+      <label for="nav-trigger" class="nav-toggle" aria-label="Menu">
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
       </label>
+      <label for="nav-trigger" class="nav-backdrop" aria-hidden="true"></label>
 
       <div class="trigger">
-        <a class="page-link" href="{{ "/about/" | relative_url }}">About</a>
-        <a class="page-link" href="{{ "/cv/" | relative_url }}">CV</a>
-        <a class="page-link" href="{{ "/" | relative_url }}">Writing</a>
-        <div class="nav-dropdown">
-          <a class="page-link dropdown-toggle" href="{{ "/publications/" | relative_url }}">Research <svg class="dropdown-arrow" viewBox="0 0 10 6" width="10" height="6"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
-          <div class="dropdown-menu">
-            <a href="{{ "/publications/" | relative_url }}">Publications</a>
-            <a href="{{ "/talks/" | relative_url }}">Talks</a>
-            <a href="{{ "/thesis/" | relative_url }}">Thesis</a>
-            <a href="{{ "/teaching/" | relative_url }}">Teaching</a>
-          </div>
-        </div>
-        <a class="page-link" href="{{ "/software/" | relative_url }}">Software</a>
-        <div class="nav-dropdown">
-          <a class="page-link dropdown-toggle" href="{{ "/reisblog/" | relative_url }}">Reizen <svg class="dropdown-arrow" viewBox="0 0 10 6" width="10" height="6"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
-          <div class="dropdown-menu">
-            <a href="{{ "/reisblog/fietsen/" | relative_url }}">Fietsen &#8217;07&#8211;&#8217;08</a>
-            <a href="{{ "/reisblog/india/" | relative_url }}">India &#8217;03&#8211;&#8217;04</a>
-          </div>
-        </div>
-        <div class="nav-dropdown">
-          <a class="page-link dropdown-toggle" href="{{ "/activities/" | relative_url }}">More <svg class="dropdown-arrow" viewBox="0 0 10 6" width="10" height="6"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
-          <div class="dropdown-menu">
-            <a href="{{ "/activities/" | relative_url }}">Activities</a>
-            <a href="{{ "/press/" | relative_url }}">Press</a>
-          </div>
-        </div>
+        {%- for item in site.data.navigation -%}
+          {%- comment -%} Is this item (or one of its children) the current page? {%- endcomment -%}
+          {%- assign item_exact = false -%}
+          {%- assign item_active = false -%}
+          {%- if page.url == item.url -%}
+            {%- assign item_exact = true -%}
+            {%- assign item_active = true -%}
+          {%- elsif item.url == "/" -%}
+            {%- if page.layout == "post" or page.url contains "/page" -%}
+              {%- assign item_active = true -%}
+            {%- endif -%}
+          {%- endif -%}
+          {%- if item.children -%}
+            {%- for child in item.children -%}
+              {%- if child.url != "/" and page.url contains child.url -%}
+                {%- assign item_active = true -%}
+              {%- endif -%}
+            {%- endfor -%}
+
+            <div class="nav-dropdown">
+              <a class="page-link dropdown-toggle{% if item_active %} active{% endif %}" href="{{ item.url | relative_url }}"{% if item_exact %} aria-current="page"{% elsif item_active %} aria-current="true"{% endif %}>{{ item.title }} <svg class="dropdown-arrow" viewBox="0 0 10 6" width="10" height="6" aria-hidden="true"><path d="M1 1l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
+              <span class="nav-group-label">{{ item.title | downcase }}</span>
+              <div class="dropdown-menu">
+                {%- for child in item.children -%}
+                  {%- assign child_active = false -%}
+                  {%- if page.url == child.url -%}
+                    {%- assign child_active = true -%}
+                  {%- elsif child.url != item.url and child.url != "/" and page.url contains child.url -%}
+                    {%- assign child_active = true -%}
+                  {%- endif -%}
+                  <a{% if child_active %} class="active" aria-current="page"{% endif %} href="{{ child.url | relative_url }}">{{ child.title }}</a>
+                {%- endfor -%}
+              </div>
+            </div>
+          {%- else -%}
+            <a class="page-link{% if item_active %} active{% endif %}"{% if item_exact %} aria-current="page"{% elsif item_active %} aria-current="true"{% endif %} href="{{ item.url | relative_url }}">{{ item.title }}</a>
+          {%- endif -%}
+        {%- endfor -%}
       </div>
     </nav>
   </div>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -24,6 +24,9 @@
   --accent-color: #c2410c;
   --route-alt-color: #3d6f9e;
   --selection-bg: rgba(194, 65, 12, 0.18);
+  --nav-backdrop: rgba(43, 42, 38, 0.4);
+  --nav-shadow: 0 16px 32px rgba(43, 42, 38, 0.16);
+  --dropdown-shadow: 0 8px 20px rgba(43, 42, 38, 0.1);
 }
 
 [data-theme="dark"] {
@@ -48,6 +51,9 @@
   --accent-color: #ff7a45;
   --route-alt-color: #7fb2e5;
   --selection-bg: rgba(255, 122, 69, 0.22);
+  --nav-backdrop: rgba(0, 0, 0, 0.6);
+  --nav-shadow: 0 16px 32px rgba(0, 0, 0, 0.55);
+  --dropdown-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
 }
 
 ::selection {
@@ -161,14 +167,20 @@ h1, h2, h3, h4, h5, h6 {
 
 .site-nav {
   border: none !important;
-  background-color: var(--header-bg);
+  background-color: transparent;
   transition: $theme-transition;
+
+  // The checkbox that drives the mobile panel; never visible itself.
+  .nav-trigger {
+    display: none;
+  }
 
   .page-link {
     color: var(--text-color);
     font-weight: 400;
     font-size: 0.85rem;
     position: relative;
+    text-decoration: none;
     transition: color 0.15s ease;
 
     &::before {
@@ -195,144 +207,356 @@ h1, h2, h3, h4, h5, h6 {
         opacity: 1;
       }
     }
-  }
 
-  .menu-icon {
-    color: var(--text-color);
-    transition: $theme-transition;
-  }
+    &:focus-visible {
+      outline: 1px solid var(--link-color);
+      outline-offset: 3px;
+    }
 
-  .trigger {
-    background-color: var(--header-bg);
-    border: 1px solid var(--border-color);
-    transition: $theme-transition;
+    // Current page/section: show the brackets, terminal-prompt style.
+    &.active {
+      color: var(--link-color);
+
+      &::before, &::after {
+        opacity: 0.6;
+      }
+    }
   }
 }
 
-.trigger {
-  border: none !important;
+// ============================================
+// Navigation: desktop (> 768px)
+// ============================================
+
+@media screen and (min-width: 769px) {
+  // Hamburger + backdrop are mobile-only
+  .site-nav label.nav-toggle,
+  .site-nav label.nav-backdrop,
+  .site-nav .nav-group-label {
+    display: none;
+  }
+
+  .nav-dropdown {
+    position: relative;
+    display: inline-block;
+
+    .dropdown-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .dropdown-arrow {
+      transition: transform 0.2s ease;
+      opacity: 0.6;
+      flex-shrink: 0;
+    }
+
+    // Invisible bridge across the gap between trigger and menu, so the
+    // dropdown doesn't close while the cursor travels down to it.
+    &::after {
+      content: "";
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      height: 0.6rem;
+    }
+
+    .dropdown-menu {
+      position: absolute;
+      top: calc(100% + 0.5rem);
+      left: -1rem;
+      min-width: 176px;
+      background: var(--header-bg);
+      border: 1px solid var(--border-strong);
+      border-radius: 0;
+      padding: 0.3rem 0;
+      box-shadow: var(--dropdown-shadow);
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(4px);
+      transition: opacity 0.15s ease, visibility 0.15s ease, transform 0.15s ease;
+      z-index: 100;
+
+      a {
+        display: block;
+        padding: 0.45rem 1rem;
+        font-size: 0.85rem;
+        font-weight: 400;
+        line-height: 1.5;
+        color: var(--text-color);
+        text-decoration: none;
+        transition: background-color 0.15s ease, color 0.15s ease;
+        white-space: nowrap;
+
+        &::before {
+          content: "> ";
+          color: var(--text-muted);
+          opacity: 0;
+          transition: opacity 0.15s ease;
+        }
+
+        &:hover {
+          background-color: var(--button-hover);
+          color: var(--link-color);
+
+          &::before {
+            opacity: 1;
+            color: var(--link-color);
+          }
+        }
+
+        &:visited {
+          color: var(--text-color);
+        }
+
+        &:visited:hover {
+          color: var(--link-color);
+        }
+
+        &.active {
+          color: var(--link-color);
+
+          &::before {
+            opacity: 1;
+          }
+        }
+      }
+    }
+
+    // Last dropdown ("More") sits at the right edge: align right so the
+    // menu never overflows the viewport.
+    &:last-child .dropdown-menu {
+      left: auto;
+      right: -0.5rem;
+    }
+
+    // Open on hover and on keyboard focus.
+    &:hover,
+    &:focus-within {
+      .dropdown-arrow {
+        transform: rotate(180deg);
+        opacity: 1;
+      }
+
+      .dropdown-menu {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
+      }
+    }
+  }
 }
 
 // ============================================
-// Navigation Dropdowns
+// Navigation: mobile (<= 768px)
+// Full-width panel below the header instead of Minima's floating box.
 // ============================================
 
-.nav-dropdown {
-  position: relative;
-  display: inline-block;
-
-  .dropdown-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
+@media screen and (max-width: 768px) {
+  .site-header {
+    position: relative;
   }
 
-  .dropdown-arrow {
-    transition: transform 0.2s ease;
-    opacity: 0.6;
-    flex-shrink: 0;
-  }
-
-  .dropdown-menu {
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    min-width: 160px;
-    background: var(--header-bg);
-    border: 1px solid var(--border-strong);
+  // Undo Minima's mobile treatment (absolute box, border, right-aligned)
+  .site-nav {
+    position: static;
+    float: right;
+    background-color: transparent;
+    border: none;
     border-radius: 0;
-    padding: 0.3rem 0;
-    box-shadow: none;
+    text-align: left;
+  }
+
+  // --- Hamburger toggle -------------------------------------------
+  .site-nav label.nav-toggle {
+    position: relative;
+    z-index: 1300;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    float: none;
+    width: 48px;
+    height: 55px;
+    margin: 0 -14px 0 0; // optical alignment with the wrapper edge
+    cursor: pointer;
+  }
+
+  .nav-toggle-bar {
+    display: block;
+    width: 20px;
+    height: 2px;
+    background: var(--text-color);
+    transition: transform 0.22s ease, opacity 0.15s ease;
+  }
+
+  .nav-trigger:checked ~ .nav-toggle {
+    .nav-toggle-bar:nth-child(1) {
+      transform: translateY(7px) rotate(45deg);
+    }
+
+    .nav-toggle-bar:nth-child(2) {
+      opacity: 0;
+    }
+
+    .nav-toggle-bar:nth-child(3) {
+      transform: translateY(-7px) rotate(-45deg);
+    }
+  }
+
+  // --- Backdrop: dims the page, tap to close ----------------------
+  .site-nav label.nav-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: block;
+    float: none;
+    width: auto;
+    height: auto;
+    background: var(--nav-backdrop);
     opacity: 0;
     visibility: hidden;
-    transition: opacity 0.15s ease, visibility 0.15s ease, transform 0.15s ease;
-    transform: translateX(-50%) translateY(4px);
-    z-index: 100;
-    margin-top: 0.25rem;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+  }
+
+  .nav-trigger:checked ~ .nav-backdrop {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  // --- Panel -------------------------------------------------------
+  // Horizontal padding matches the page wrapper so menu text lines up
+  // with the content below it.
+  .site-nav .trigger {
+    --nav-pad: 30px;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1200;
+    clear: none;
+    background: var(--header-bg);
+    border-bottom: 1px solid var(--border-strong);
+    box-shadow: var(--nav-shadow);
+    padding: 0.5rem 0 1.1rem;
+    max-height: calc(100vh - 60px);
+    max-height: calc(100dvh - 60px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .site-nav input ~ .trigger {
+    display: block;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s ease;
+  }
+
+  .site-nav input:checked ~ .trigger {
+    display: block;
+    padding-bottom: 1.1rem;
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  // Keep the page from scrolling underneath the open menu.
+  body:has(.nav-trigger:checked) {
+    overflow: hidden;
+  }
+
+  // --- Links -------------------------------------------------------
+  .site-nav .page-link {
+    display: block;
+    margin: 0;
+    padding: 0.65rem var(--nav-pad);
+    font-size: 0.95rem;
+    line-height: 1.4;
+
+    // Bracket affordance is a hover effect; not useful on touch.
+    &::before, &::after {
+      display: none;
+    }
+
+    &.active {
+      color: var(--link-color);
+      box-shadow: inset 2px 0 0 var(--accent-color);
+    }
+  }
+
+  // --- Groups ------------------------------------------------------
+  // Sections get a muted "// label" header; children sit flush left
+  // underneath it, no fussy indentation.
+  .site-nav .nav-dropdown {
+    display: block;
+    margin-top: 1rem;
+  }
+
+  // The desktop trigger link is redundant here: its destination is
+  // listed in the group itself.
+  .site-nav .dropdown-toggle {
+    display: none;
+  }
+
+  .nav-group-label {
+    display: block;
+    padding: 0 var(--nav-pad);
+    margin-bottom: 0.1rem;
+    font-size: 0.7rem;
+    line-height: 1.4;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+
+    &::before {
+      content: "// ";
+      color: var(--accent-color);
+    }
+  }
+
+  .site-nav .dropdown-menu {
+    position: static;
+    transform: none;
+    opacity: 1;
+    visibility: visible;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    margin: 0;
+    min-width: 0;
+    background: transparent;
 
     a {
       display: block;
-      padding: 0.45rem 1rem;
+      padding: 0.55rem var(--nav-pad);
       font-size: 0.9rem;
-      font-weight: 500;
+      line-height: 1.4;
       color: var(--text-color);
       text-decoration: none;
-      transition: background-color 0.15s ease, color 0.15s ease;
-      white-space: nowrap;
-
-      &:hover {
-        background-color: var(--button-bg);
-        color: var(--link-color);
-      }
 
       &:visited {
         color: var(--text-color);
       }
-    }
-  }
 
-  &:hover {
-    .dropdown-arrow {
-      transform: rotate(180deg);
-      opacity: 1;
-    }
+      &:hover {
+        color: var(--link-color);
+      }
 
-    .dropdown-menu {
-      opacity: 1;
-      visibility: visible;
-      transform: translateX(-50%) translateY(0);
+      &.active {
+        color: var(--link-color);
+        box-shadow: inset 2px 0 0 var(--accent-color);
+      }
     }
   }
 }
 
-// Mobile: flatten dropdowns into the hamburger menu
+// Narrow phones: match Minima's tighter wrapper padding.
 @media screen and (max-width: 600px) {
-  // Match Minima's mobile nav styling for dropdown containers
-  .site-nav .nav-dropdown {
-    display: block;
-
-    .dropdown-toggle {
-      // Match Minima's .page-link mobile styling exactly
-      display: block;
-      padding: 5px 10px;
-      margin-left: 20px;
-      line-height: 1.5;
-    }
-
-    .dropdown-arrow {
-      display: none;
-    }
-
-    .dropdown-menu {
-      position: static;
-      transform: none;
-      opacity: 1;
-      visibility: visible;
-      border: none;
-      box-shadow: none;
-      padding: 0;
-      margin: 0;
-      min-width: 0;
-      background: transparent;
-
-      a {
-        display: block;
-        padding: 3px 10px 3px 40px;
-        font-size: 0.85rem;
-        color: var(--text-muted);
-        line-height: 1.6;
-
-        &:hover {
-          background-color: transparent;
-          color: var(--link-color);
-        }
-
-        &:visited {
-          color: var(--text-muted);
-        }
-      }
-    }
+  .site-nav .trigger {
+    --nav-pad: 15px;
   }
 }
 
@@ -775,7 +999,9 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
-@media screen and (max-width: 600px) {
+// Below the nav breakpoint the hamburger occupies the top-right corner,
+// so the utility buttons move to the bottom.
+@media screen and (max-width: 768px) {
   .theme-toggle {
     top: auto;
     bottom: 16px;


### PR DESCRIPTION
Fixes the mobile menu disappearing behind the Leaflet maps, and redesigns the menu for both mobile and desktop.

## Mobile (≤ 768px)
- Replaces Minima's floating right-aligned box with a **full-width panel** that drops down below the header — left-aligned, generous tap targets.
- Hierarchy without indentation: flat links first (About, CV, Writing, Software), then groups under muted `// research` / `// reizen` / `// more` section labels, matching the site's terminal aesthetic.
- Dimmed **backdrop**: tap anywhere outside to close; body scroll is locked while open.
- Animated hamburger → ✕ (pure CSS, still no JS).
- Panel sits **above the Leaflet maps** (the old menu had no z-index, and the map's stacking context painted over it — the reported bug).
- `Reisarchief` added to the Reizen group so the archive landing page stays reachable (its parent link is hidden on mobile).

## Desktop (> 768px)
- Hover dropdowns kept, plus:
  - **keyboard support** — dropdowns open on `:focus-within`;
  - a hover **bridge** over the gap between trigger and menu, so it no longer closes while the cursor travels down;
  - compact, left-aligned menus with `>` hover markers (the "More" menu right-aligns so it can't overflow the viewport);
  - **current-page indication** using the site's bracket motif: the active section reads `[ Research ]`, and the active dropdown item gets `>` + accent.
- Mobile breakpoint raised from 600px to 768px — the 7-item mono nav crammed badly in the 600–768px range.
- Nav links drop the global underline; structure + brackets are the affordance.

## Structure
- Navigation now lives in `_data/navigation.yml` and drives both renderings from one include, including active-page detection (`aria-current`).
- Theme/search utility buttons move to the bottom corner on all hamburger widths (previously they collided with the hamburger between 600–768px).

Verified with a local Jekyll build and Playwright screenshots: phone/tablet/desktop, light + dark, menu open/closed, dropdown hover states, and the reisblog map pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_012VpG19uFKZwUrbR5SKG1VN)_