### PR TITLE
Add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes


### PR DESCRIPTION
Adds `.github/workflows/release.yml`: pushing a `v*` tag creates a GitHub release with auto-generated notes (via `gh release create --generate-notes`, using the workflow's `GITHUB_TOKEN` with `contents: write`).

This repo had no release mechanism yet; this enables cutting the first release (`v1.0.0`) and any future ones by just pushing a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012J8HNYYqeHhJsNUV44ZkA6

---
_Generated by [Claude Code](https://claude.ai/code/session_012J8HNYYqeHhJsNUV44ZkA6)_