### PR TITLE
Fix invisible click layer from closed mobile menu

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -452,6 +452,7 @@ h1, h2, h3, h4, h5, h6 {
     display: block;
     opacity: 0;
     visibility: hidden;
+    pointer-events: none;
     transform: translateY(-6px);
     transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s ease;
   }
@@ -461,6 +462,7 @@ h1, h2, h3, h4, h5, h6 {
     padding-bottom: 1.1rem;
     opacity: 1;
     visibility: visible;
+    pointer-events: auto;
     transform: translateY(0);
   }
 
@@ -517,11 +519,12 @@ h1, h2, h3, h4, h5, h6 {
     }
   }
 
+  // NOTE: no opacity/visibility overrides here — visibility is inherited,
+  // and re-enabling it on children would leave invisible-but-clickable
+  // links floating over the page while the panel is closed.
   .site-nav .dropdown-menu {
     position: static;
     transform: none;
-    opacity: 1;
-    visibility: visible;
     border: none;
     box-shadow: none;
     padding: 0;


### PR DESCRIPTION
Follow-up to #76: with the mobile menu **closed**, taps on the page were being swallowed by invisible nav links.

**Cause:** the mobile reset for `.dropdown-menu` declared `opacity: 1; visibility: visible` (a leftover from countering the desktop dropdown's hidden state). `visibility` is inherited, and a child's `visible` overrides the closed panel's `hidden` — while the panel's `opacity: 0` only makes the subtree transparent, it does **not** disable hit-testing. Result: Publications/Talks/Fietsen/Press floated invisibly over the content and intercepted taps.

**Fix:**
- Drop the `opacity`/`visibility` overrides on the mobile group lists so they simply inherit the panel's state.
- Add `pointer-events: none` on the closed panel (re-enabled when open) as a guard against this whole class of bug.

Verified with Playwright hit-testing on the built site: with the menu closed, `elementFromPoint` across the content area now returns actual page content (hero, intro, post cards); with the menu open, the group links are still clickable; tapping the backdrop closes the menu and restores normal tapping.

---
_Generated by [Claude Code](https://claude.ai/code/session_012VpG19uFKZwUrbR5SKG1VN)_