### PR TITLE
Cache-bust CV PDF and thumbnail links

### DIFF
--- a/about.markdown
+++ b/about.markdown
@@ -24,8 +24,8 @@ Cambridge UK and Yandex in Moscow. My [publications](/publications/) have receiv
 For a full overview of my appointments, education, students, talks, publications,
 and activities, see my [CV](/cv/).
 
-<a class="cv-preview" href="/assets/cv-anne-schuth.pdf">
-  <img src="/assets/cv-thumbnail.png" alt="Eerste pagina van het CV van Anne Schuth" />
+<a class="cv-preview" href="/assets/cv-anne-schuth.pdf?v={{ site.time | date: '%s' }}">
+  <img src="/assets/cv-thumbnail.png?v={{ site.time | date: '%s' }}" alt="Eerste pagina van het CV van Anne Schuth" />
 </a>
 
 ## Archive

--- a/cv.markdown
+++ b/cv.markdown
@@ -15,7 +15,7 @@ permalink: /cv/
     &middot; <a href="https://scholar.google.com/citations?user=Y3ahb_wAAAAJ&hl=en">Google Scholar</a>
   </p>
   <p class="cv-pdf-link no-print">
-    <a href="/assets/cv-anne-schuth.pdf"><i class="fa fa-file-pdf-o"></i> Download as PDF</a>
+    <a href="/assets/cv-anne-schuth.pdf?v={{ site.time | date: '%s' }}"><i class="fa fa-file-pdf-o"></i> Download as PDF</a>
   </p>
 </div>
 


### PR DESCRIPTION
Browsers — especially built-in PDF viewers and mobile browsers — hold on to cached copies of the CV long past GitHub Pages' `max-age=600`, so visitors kept seeing an outdated PDF after a regeneration.

This appends the Jekyll build timestamp as a query string (`?v={{ site.time | date: '%s' }}`) to the CV PDF links on `/cv/` and `/about/` and to the thumbnail image, so every deploy produces a fresh URL and stale client caches can't serve the old file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012J8HNYYqeHhJsNUV44ZkA6

---
_Generated by [Claude Code](https://claude.ai/code/session_012J8HNYYqeHhJsNUV44ZkA6)_